### PR TITLE
Implement Players CRUD

### DIFF
--- a/src/app/api/players/[id]/route.ts
+++ b/src/app/api/players/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const player = await prisma.player.findUnique({
+    where: { id: params.id },
+    include: { user: true, team: true },
+  })
+  if (!player) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json(player)
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const data = await request.json()
+  const { name, email, password, teamId, stats } = data
+
+  const player = await prisma.player.findUnique({ where: { id: params.id } })
+  if (!player) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  await prisma.player.update({
+    where: { id: params.id },
+    data: { teamId, stats },
+  })
+
+  if (name || email || password) {
+    const userData: any = {}
+    if (name) userData.name = name
+    if (email) userData.email = email
+    if (password) userData.password = await bcrypt.hash(password, 10)
+    await prisma.user.update({ where: { id: player.userId }, data: userData })
+  }
+
+  const updated = await prisma.player.findUnique({
+    where: { id: params.id },
+    include: { user: true, team: true },
+  })
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const player = await prisma.player.findUnique({ where: { id: params.id } })
+  if (!player) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  await prisma.player.delete({ where: { id: params.id } })
+  await prisma.user.delete({ where: { id: player.userId } })
+  return NextResponse.json({ message: 'Deleted' })
+}

--- a/src/app/api/players/route.ts
+++ b/src/app/api/players/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+
+export async function GET() {
+  const players = await prisma.player.findMany({ include: { user: true, team: true } })
+  return NextResponse.json(players)
+}
+
+export async function POST(request: Request) {
+  const data = await request.json()
+  const { name, email, password, academyId, teamId } = data
+  if (!name || !email || !password || !academyId) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+  const hashed = await bcrypt.hash(password, 10)
+  const user = await prisma.user.create({
+    data: { name, email, password: hashed, role: 'PLAYER', academyId },
+  })
+  const player = await prisma.player.create({
+    data: { userId: user.id, teamId },
+  })
+  return NextResponse.json({ ...player, user }, { status: 201 })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
           <nav className="flex flex-col gap-2">
             <Link href="/dashboard" className="px-4 py-2 rounded hover:bg-blue-100">Dashboard</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Teams</Link>
-            <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Players</Link>
+            <Link href="/players" className="px-4 py-2 rounded hover:bg-blue-100">Players</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Matches</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Sessions</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Messages</Link>

--- a/src/app/players/DeletePlayerButton.tsx
+++ b/src/app/players/DeletePlayerButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+export default function DeletePlayerButton({ id }: { id: string }) {
+  const router = useRouter()
+  const [loading, setLoading] = useState(false)
+
+  async function handleDelete() {
+    if (!confirm('Delete this player?')) return
+    setLoading(true)
+    await fetch(`/api/players/${id}`, { method: 'DELETE' })
+    setLoading(false)
+    router.refresh()
+  }
+
+  return (
+    <button onClick={handleDelete} disabled={loading} className="text-red-600">
+      {loading ? 'Deleting...' : 'Delete'}
+    </button>
+  )
+}

--- a/src/app/players/PlayerForm.tsx
+++ b/src/app/players/PlayerForm.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+type PlayerFormProps = {
+  teams: { id: string; name: string }[]
+  academies: { id: string; name: string }[]
+  player?: any
+}
+
+export default function PlayerForm({ teams, academies, player }: PlayerFormProps) {
+  const router = useRouter()
+  const [name, setName] = useState(player?.user.name ?? '')
+  const [email, setEmail] = useState(player?.user.email ?? '')
+  const [password, setPassword] = useState('')
+  const [academyId, setAcademyId] = useState(player?.user.academyId ?? academies[0]?.id ?? '')
+  const [teamId, setTeamId] = useState(player?.teamId ?? '')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const method = player ? 'PUT' : 'POST'
+    const url = player ? `/api/players/${player.id}` : '/api/players'
+    await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password, academyId, teamId: teamId || null }),
+    })
+    router.push('/players')
+    router.refresh()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-6">
+      <div>
+        <label className="block text-sm font-medium">Name</label>
+        <input className="border px-2 py-1 w-full" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Email</label>
+        <input type="email" className="border px-2 py-1 w-full" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      </div>
+      {!player && (
+        <div>
+          <label className="block text-sm font-medium">Password</label>
+          <input type="password" className="border px-2 py-1 w-full" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+      )}
+      <div>
+        <label className="block text-sm font-medium">Academy</label>
+        <select className="border px-2 py-1 w-full" value={academyId} onChange={(e) => setAcademyId(e.target.value)}>
+          {academies.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Team</label>
+        <select className="border px-2 py-1 w-full" value={teamId ?? ''} onChange={(e) => setTeamId(e.target.value)}>
+          <option value="">Unassigned</option>
+          {teams.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
+        {player ? 'Update' : 'Create'}
+      </button>
+    </form>
+  )
+}

--- a/src/app/players/[id]/edit/page.tsx
+++ b/src/app/players/[id]/edit/page.tsx
@@ -1,0 +1,21 @@
+import PlayerForm from '../../PlayerForm'
+import { prisma } from '@/lib/prisma'
+
+export default async function EditPlayerPage({ params }: { params: { id: string } }) {
+  const player = await prisma.player.findUnique({
+    where: { id: params.id },
+    include: { user: true, team: true },
+  })
+  if (!player) {
+    return <div className="p-6">Player not found</div>
+  }
+  const teams = await prisma.team.findMany()
+  const academies = await prisma.academy.findMany()
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Edit Player</h1>
+      <PlayerForm player={player} teams={teams} academies={academies} />
+    </main>
+  )
+}

--- a/src/app/players/new/page.tsx
+++ b/src/app/players/new/page.tsx
@@ -1,0 +1,14 @@
+import PlayerForm from '../PlayerForm'
+import { prisma } from '@/lib/prisma'
+
+export default async function NewPlayerPage() {
+  const teams = await prisma.team.findMany()
+  const academies = await prisma.academy.findMany()
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">New Player</h1>
+      <PlayerForm teams={teams} academies={academies} />
+    </main>
+  )
+}

--- a/src/app/players/page.tsx
+++ b/src/app/players/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { prisma } from '@/lib/prisma'
+import DeletePlayerButton from './DeletePlayerButton'
+
+export default async function PlayersPage() {
+  const players = await prisma.player.findMany({ include: { user: true, team: true } })
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Players</h1>
+      <Link href="/players/new" className="bg-blue-500 text-white px-4 py-2 rounded">
+        Add Player
+      </Link>
+      <table className="min-w-full bg-white mt-4">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Email</th>
+            <th className="px-4 py-2 text-left">Team</th>
+            <th className="px-4 py-2 text-left">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {players.map((p) => (
+            <tr key={p.id} className="border-t">
+              <td className="px-4 py-2">{p.user.name}</td>
+              <td className="px-4 py-2">{p.user.email}</td>
+              <td className="px-4 py-2">{p.team?.name ?? '-'}</td>
+              <td className="px-4 py-2 space-x-2">
+                <Link href={`/players/${p.id}/edit`} className="text-blue-600">
+                  Edit
+                </Link>
+                <DeletePlayerButton id={p.id} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  )
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['query'],
+  })
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma


### PR DESCRIPTION
## Summary
- link Players in sidebar
- set up Prisma helper
- add API routes for players
- add players pages with listing and forms

## Testing
- `npm install` *(fails: could not resolve dependency)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cf5042f48323ba1259f5d413ac8b