### PR TITLE
Implement coach CRUD

### DIFF
--- a/src/app/api/coaches/[id]/route.ts
+++ b/src/app/api/coaches/[id]/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const coach = await prisma.user.findFirst({
+    where: { id: params.id, role: 'COACH' },
+  });
+  if (!coach) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(coach);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const data = await request.json();
+  const { name, email, password } = data;
+  const updateData: any = {};
+  if (name) updateData.name = name;
+  if (email) updateData.email = email;
+  if (password) {
+    updateData.password = await bcrypt.hash(password, 10);
+  }
+  const coach = await prisma.user.update({
+    where: { id: params.id },
+    data: updateData,
+  });
+  return NextResponse.json(coach);
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  await prisma.user.delete({ where: { id: params.id } });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/coaches/route.ts
+++ b/src/app/api/coaches/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+export async function GET() {
+  const coaches = await prisma.user.findMany({
+    where: { role: 'COACH' },
+    select: { id: true, name: true, email: true },
+  });
+  return NextResponse.json(coaches);
+}
+
+export async function POST(request: Request) {
+  const data = await request.json();
+  const { name, email, password } = data;
+  const academy = await prisma.academy.findFirst();
+  if (!academy) {
+    return NextResponse.json({ error: 'No academy found' }, { status: 400 });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  const coach = await prisma.user.create({
+    data: {
+      name,
+      email,
+      password: hashed,
+      role: 'COACH',
+      academyId: academy.id,
+    },
+  });
+  return NextResponse.json(coach, { status: 201 });
+}

--- a/src/app/coaches/page.tsx
+++ b/src/app/coaches/page.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Coach {
+  id: string;
+  name: string;
+  email: string;
+}
+
+export default function CoachesPage() {
+  const [coaches, setCoaches] = useState<Coach[]>([]);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [editing, setEditing] = useState<Coach | null>(null);
+
+  const fetchCoaches = async () => {
+    const res = await fetch('/api/coaches');
+    if (res.ok) {
+      setCoaches(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    fetchCoaches();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (editing) {
+      await fetch(`/api/coaches/${editing.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
+      });
+    } else {
+      await fetch('/api/coaches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
+      });
+    }
+    setName('');
+    setEmail('');
+    setPassword('');
+    setEditing(null);
+    fetchCoaches();
+  };
+
+  const handleEdit = (coach: Coach) => {
+    setEditing(coach);
+    setName(coach.name);
+    setEmail(coach.email);
+  };
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/coaches/${id}`, { method: 'DELETE' });
+    fetchCoaches();
+  };
+
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Coaches</h1>
+      <form onSubmit={handleSubmit} className="space-y-2 mb-6">
+        <input
+          className="border p-2 rounded w-full"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          className="border p-2 rounded w-full"
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          className="border p-2 rounded w-full"
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required={!editing}
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          {editing ? 'Update Coach' : 'Create Coach'}
+        </button>
+        {editing && (
+          <button
+            type="button"
+            className="ml-2 px-4 py-2 bg-gray-300 rounded"
+            onClick={() => {
+              setEditing(null);
+              setName('');
+              setEmail('');
+              setPassword('');
+            }}
+          >
+            Cancel
+          </button>
+        )}
+      </form>
+      <table className="min-w-full bg-white border">
+        <thead>
+          <tr className="border-b">
+            <th className="p-2 text-left">Name</th>
+            <th className="p-2 text-left">Email</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {coaches.map((coach) => (
+            <tr key={coach.id} className="border-b">
+              <td className="p-2">{coach.name}</td>
+              <td className="p-2">{coach.email}</td>
+              <td className="p-2 space-x-2 text-center">
+                <button
+                  className="px-2 py-1 bg-green-500 text-white rounded"
+                  onClick={() => handleEdit(coach)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="px-2 py-1 bg-red-500 text-white rounded"
+                  onClick={() => handleDelete(coach.id)}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,7 @@ export default function RootLayout({
           <h2 className="text-2xl font-bold mb-8">Fútbol Academy</h2>
           <nav className="flex flex-col gap-2">
             <Link href="/dashboard" className="px-4 py-2 rounded hover:bg-blue-100">Dashboard</Link>
+            <Link href="/coaches" className="px-4 py-2 rounded hover:bg-blue-100">Coaches</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Teams</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Players</Link>
             <Link href="#" className="px-4 py-2 rounded hover:bg-blue-100">Matches</Link>


### PR DESCRIPTION
## Summary
- add navigation link to Coaches
- implement API routes for coach CRUD
- add UI page to manage coaches

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855cfad13d88323a122dab22bd1807c